### PR TITLE
(feature) task for linux services (no agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 
 ## Description
 
-This module provides the service task. This task allows you to manage and inspect the state of services, including starting, stopping, enabling, and disabling services.
+This module provides services tasks, There are two kinds of tasks. The default task: that uses the puppet agent on the target node to manage and inspect the state of services. The linux task: that manipulates services on a linux derivative without a puppet agent installed on the target node.
+
 
 ## Requirements
 This module is compatible with Puppet Enterprise and Puppet Bolt.
@@ -24,6 +25,8 @@ This module is compatible with Puppet Enterprise and Puppet Bolt.
 
 To run a service task, use the task command, specifying the action and the name of the service.
 
+### Default task
+
 * With PE on the command line, run `puppet task run service action=<ACTION> name=<SERVICE_NAME>`.
 * With Bolt on the command line, run `bolt task run service action=<ACTION> name=<SERVICE_NAME>`.
 
@@ -31,6 +34,16 @@ For example, to check the status of the Apache httpd service, run:
 
 * With PE, run `puppet task run service action=status name=httpd --nodes neptune`
 * With Bolt, run `bolt task run service action=status name=httpd --nodes neptune --modulepath ~/modules`
+
+### Linux task
+
+* With PE on the command line, run `puppet task run service::linux action=<ACTION> name=<SERVICE_NAME>`.
+* With Bolt on the command line, run `bolt task run service::linux action=<ACTION> name=<SERVICE_NAME>`.
+
+For example, to check the status of the Apache httpd service, run:
+
+* With PE, run `puppet task run service::linux action=status name=httpd --nodes neptune`
+* With Bolt, run `bolt task run service::linux action=status name=httpd --nodes neptune --modulepath ~/modules`
 
 You can also run tasks in the PE console. See PE task documentation for complete information.
 
@@ -45,4 +58,3 @@ For a complete list of services that are supported see the Puppet [services](htt
 To display help for the service task, run `puppet task show service`
 
 To show help for the task CLI, run `puppet task run --help` or `bolt task run --help`
-

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -1,0 +1,28 @@
+# run a test task
+require 'spec_helper_acceptance'
+# bolt regexes
+# expect_multiple_regexes(result: result, regexes: [%r{"status":"(stopped|in_sync)"}, %r{Ran on 1 node}])
+# expect_multiple_regexes(result: result, regexes: [%r{"status":"stopped"}, %r{"enabled":"false"}, %r{Ran on 1 node}])
+
+describe 'linux service task', unless: fact_on(default, 'osfamily') == 'windows' do
+  package_to_use = ''
+  before(:all) do
+    if fact_on(default, 'osfamily') == 'RedHat' && fact_on(default, 'operatingsystemrelease') < '6'
+      run_task(task_name: 'service::linux', params: 'action=stop name=syslog')
+    end
+    package_to_use = 'rsyslog'
+    apply_manifest("package { \"#{package_to_use}\": ensure => present, }")
+  end
+  describe 'stop action' do
+    it "stop #{package_to_use}" do
+      result = run_task(task_name: 'service::linux', params: "action=stop name=#{package_to_use}")
+      expect_multiple_regexes(result: result, regexes: [%r{status.*(stop)}, %r{#{task_summary_line}}])
+    end
+  end
+  describe 'start action' do
+    it "start #{package_to_use}" do
+      result = run_task(task_name: 'service::linux', params: "action=start name=#{package_to_use}")
+      expect_multiple_regexes(result: result, regexes: [%r{status.*(start)}, %r{#{task_summary_line}}])
+    end
+  end
+end

--- a/spec/acceptance/nodesets/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/ubuntu-14.04.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-14.04:
+    roles:
+      - agent
+      - default
+    platform: ubuntu-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  type: foss

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,0 +1,14 @@
+{
+  "description": "Manage the state of services (without a puppet agent)",
+  "input_method": "environment",
+  "parameters": {
+    "action": {
+      "description": "The operation (start, stop) to perform on the service",
+      "type": "Enum[start, stop]"
+    },
+    "name": {
+      "description": "The name of the service to operate on.",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -1,0 +1,46 @@
+inux.sh: line 19: local: can only be used in a function
+#!/bin/bash
+
+action="$PT_action"
+name="$PT_name"
+service_managers[0]="systemctl"
+service_managers[1]="service"
+service_managers[2]="initctl"
+
+# example cli /opt/puppetlabs/puppet/bin/bolt  task run service::linux action=stop name=ntp --nodes localhost --modulepath /etc/puppetlabs/code/modules --password puppet --user root
+
+check_command_exists() {
+  (which "$1") > /dev/null 2>&1
+  command_exists=$?
+  return $command_exists
+}
+
+for service_manager in "${service_managers[@]}"
+do
+  check_command_exists "$service_manager"
+  command_exists=$?
+  if [ $command_exists -eq 0 ]; then
+    command_line="$service_manager $action $name"
+    if [ $service_manager == "service" ]; then
+      command_line="$service_manager $name $action"
+    fi
+    output=$($command_line 2>&1)
+    status_from_command=$?
+    # set up our status and exit code
+    if [ $status_from_command -eq 0 ]; then
+      echo "{ \"status\": \"$name $action\" }"
+      exit 0
+    else
+      # initd is special, starting an already started service is an error
+      if [[ $service_manager == "service" && "$output" == *"Job is already running"* ]]; then
+        echo "{ \"status\": \"$name $action\" }"
+        exit 0
+      fi
+      echo "{ \"status\": \"unable to run command '$command_line'\" }"
+      exit $status_from_command
+    fi
+  fi
+done
+
+echo "{ \"status\": \"No service managers found\" }"
+exit 255


### PR DESCRIPTION
root@debian-8-x64:/home/vagrant# /opt/puppetlabs/puppet/bin/bolt  task run service::linux action=start name=ntp --nodes localhost --modulepath /etc/puppetlabs/code/modules --password puppet --user root
Started on localhost...
Finished on localhost:
  { 'Status': 'started' }
  {
  }
Ran on 1 node in 0.56 seconds
root@debian-8-x64:/home/vagrant# /opt/puppetlabs/puppet/bin/bolt  task run service::linux action=stop name=ntp --nodes localhost --modulepath /etc/puppetlabs/code/modules --password puppet --user root
Started on localhost...
Finished on localhost:
  { 'Status': 'stopped' }
  {
  }
Ran on 1 node in 0.58 seconds