### PR TITLE
(MODULES-6800) Add Windows service management

### DIFF
--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -1,0 +1,14 @@
+{
+  "description": "Manage the state of Windows services (without a puppet agent)",
+  "input_method": "powershell",
+  "parameters": {
+    "action": {
+      "description": "The operation (start, stop, restart, status) to perform on the service",
+      "type": "Enum[start, stop, restart, status]"
+    },
+    "name": {
+      "description": "The short name of the Windows service to operate on.",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -51,9 +51,10 @@ function Invoke-ServiceAction($Service, $Action)
   return $status
 }
 
-
-$service = Get-Service -Name $Name
-$status = Invoke-ServiceAction -Service $service -Action $action
+try
+{
+  $service = Get-Service -Name $Name
+  $status = Invoke-ServiceAction -Service $service -Action $action
 
 # TODO: could use ConvertTo-Json, but that requires PS3
 # if embedding in literal, should make sure Name / Status doesn't need escaping
@@ -66,3 +67,19 @@ Write-Host @"
   "startType"   : "$($service.StartType)"
 }
 "@
+}
+catch
+{
+  Write-Host @"
+  {
+    "status"  : "failure",
+    "name"    : "$Name",
+    "action"  : "$Action",
+    "_error"  : {
+      "msg" : "Unable to perform '$Action' on '$Name': $($_.Exception.Message)",
+      "kind": "powershell_error",
+      "details" : {}
+    }
+  }
+"@
+}

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -1,0 +1,60 @@
+[CmdletBinding()]
+param(
+  # NOTE: init.json cannot yet be shared, so must have windows.json / windows.ps1
+  [Parameter(Mandatory = $true)]
+  [String]
+  $Name,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('start', 'stop', 'restart', 'status')]
+  [String]
+  $Action
+)
+
+$ErrorActionPreference = 'Stop'
+
+$inSyncStatus = 'in_sync'
+$status = $null
+$service = Get-Service -Name $Name
+
+switch ($Action)
+{
+  'start'
+  {
+    if ($service.Status -eq 'Running') { $status = $InSyncStatus }
+    else { Start-Service $service }
+  }
+  'stop'
+  {
+    if ($service.Status -eq 'Stopped') { $status = $InSyncStatus }
+    else { Stop-Service $service }
+  }
+  'restart'
+  {
+    Restart-Service $service
+    $status = 'restarted'
+  }
+  # no-op since status always returned
+  'status' { }
+}
+
+# user action
+if ($status -eq $null)
+{
+  # https://msdn.microsoft.com/en-us/library/system.serviceprocess.servicecontrollerstatus(v=vs.110).aspx
+  # ContinuePending, Paused, PausePending, Running, StartPending, Stopped, StopPending
+  $status = $service.Status
+  if ($status -eq 'Running') { $status = 'started' }
+}
+
+# TODO: could use ConvertTo-Json, but that requires PS3
+# if embedding in literal, should make sure Name / Status doesn't need escaping
+Write-Host @"
+{
+  "name"        : "$($service.Name)",
+  "action"      : "$Action",
+  "displayName" : "$($service.DisplayName)",
+  "status"      : "$status",
+  "startType"   : "$($service.StartType)"
+}
+"@


### PR DESCRIPTION
- Basic ability to start / stop / restart and query status on
   a service given a name

 - Follows the same model as existing task where the state machine
   flows like:

   - status
     status: started
   - start
     status: in_sync
   - restart
     status: restarted
   - status
     status: started
   - stop
     status: stopped

   - status
     status: stopped
   - stop
     status: in_sync
   - restart
     status: restarted

   - status
     status: started

   NOTE: Windows `Running` status is converted to `started`

 - For states Puppet doesn't currently model, but that Windows will
   return, return those values:

   ContinuePending
   Paused
   PausePending
   StartPending
   StopPending