### PR TITLE
(maint) - Fix so that W32Time is running at start of test

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -19,6 +19,7 @@ describe 'service task' do
       apply_manifest("package { \"#{package_to_use}\": ensure => present, }")
     else
       package_to_use = 'W32Time'
+      run_and_expect("action=start name=#{package_to_use}", [%r{status.*(in_sync|started)}, %r{#{task_summary_line}}])
     end
   end
   describe 'enable action' do


### PR DESCRIPTION
Unlike with 'ryslog' and 'syslog' 'W32Time' does not seem to run by default. As such the the restart test fails when called now that it has been moved up and the previously placed stop test did not accurately test it's associated task.