### PR TITLE
(MODULES-8391) Enable implementations on the init task and hide others

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    service: "#{source_dir}"

--- a/.sync.yml
+++ b/.sync.yml
@@ -5,9 +5,15 @@
     - set: docker/ubuntu-14.04
   docker_defaults:
     bundler_args: ""
+    script: bundle exec rake task_acceptance
   secure: ""
   branches:
     - release
+  remove_includes:
+    - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.4
+    - env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8
+      rvm: 2.1.9
 
 Gemfile:
   optional:
@@ -25,6 +31,8 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
+      - gem: 'bolt'
+        version: '~> 1.4'
 
 .gitlab-ci.yml:
   unmanaged: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/centos-7 BEAKER_TESTMODE=apply
       rvm: 2.5.1
-      script: bundle exec rake beaker
+      script: bundle exec rake task_acceptance
       services: docker
       sudo: required
     -
@@ -35,19 +35,13 @@ matrix:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/ubuntu-14.04 BEAKER_TESTMODE=apply
       rvm: 2.5.1
-      script: bundle exec rake beaker
+      script: bundle exec rake task_acceptance
       services: docker
       sudo: required
     -
       env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
       env: CHECK=parallel_spec
-    -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.4
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec RUBYGEMS_VERSION=2.7.8 BUNDLER_VERSION=1.17.3
-      rvm: 2.1.9
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-win-system-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "bolt", '~> 1.4',                               require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -74,3 +74,6 @@ EOM
   end
 end
 
+task :task_acceptance => [:spec_prep, :beaker] do
+  # nothing to do
+end

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -1,34 +1,57 @@
 # run a test task
 require 'spec_helper_acceptance'
-# bolt regexes
-# expect_multiple_regexes(result: result, regexes: [%r{"status":"(stopped|in_sync)"}, %r{Ran on 1 node}])
-# expect_multiple_regexes(result: result, regexes: [%r{"status":"stopped"}, %r{"enabled":"false"}, %r{Ran on 1 node}])
+require 'beaker-task_helper/inventory'
+require 'bolt_spec/run'
 
-describe 'linux service task', unless: fact_on(default, 'osfamily') == 'windows' do
-  package_to_use = ''
-  before(:all) do
-    if fact_on(default, 'osfamily') == 'RedHat' && fact_on(default, 'operatingsystemrelease') < '6'
-      run_task(task_name: 'service::linux', params: 'action=stop name=syslog')
-    end
-    package_to_use = 'rsyslog'
-    apply_manifest("package { \"#{package_to_use}\": ensure => present, }")
+describe 'linux service task', unless: fact('osfamily') == 'windows' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  def module_path
+    RSpec.configuration.module_path
   end
+
+  def config
+    { 'modulepath' => module_path }
+  end
+
+  def inventory
+    hosts_to_inventory
+  end
+
+  def run(params)
+    run_task('service::linux', 'default', params, config: config, inventory: inventory)
+  end
+
+  package_to_use = 'rsyslog'
+  before(:all) do
+    if fact('osfamily') == 'RedHat' && fact('operatingsystemrelease') < '6'
+      run('action' => 'stop', 'name' => 'syslog')
+    end
+    apply_manifest_on(default, "package { \"#{package_to_use}\": ensure => present, }")
+  end
+
   describe 'stop action' do
     it "stop #{package_to_use}" do
-      result = run_task(task_name: 'service::linux', params: "action=stop name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{status.*(stop)}, %r{#{task_summary_line}}])
+      result = run('action' => 'stop', 'name' => package_to_use)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to match(%r{stop})
     end
   end
+
   describe 'start action' do
     it "start #{package_to_use}" do
-      result = run_task(task_name: 'service::linux', params: "action=start name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{status.*(start)}, %r{#{task_summary_line}}])
+      result = run('action' => 'start', 'name' => package_to_use)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to match(%r{start})
     end
   end
+
   describe 'restart action' do
     it "restart #{package_to_use}" do
-      result = run_task(task_name: 'service::linux', params: "action=restart name=#{package_to_use}")
-      expect_multiple_regexes(result: result, regexes: [%r{status.*(restart)}, %r{#{task_summary_line}}])
+      result = run('action' => 'restart', 'name' => package_to_use)
+      expect(result[0]['status']).to eq('success')
+      expect(result[0]['result']['status']).to match(%r{restart})
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,12 +4,10 @@ require 'puppet'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
-require 'beaker-task_helper'
 
 run_puppet_install_helper
 configure_type_defaults_on(hosts)
-install_ca_certs unless pe_install?
-install_bolt_on(hosts) unless pe_install?
+install_ca_certs
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 
@@ -17,8 +15,6 @@ RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
 
-  # Configure all nodes in nodeset
-  c.before :suite do
-    run_puppet_access_login(user: 'admin') if pe_install?
-  end
+  c.add_setting :module_path
+  c.module_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures', 'modules')
 end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -3,7 +3,7 @@
   "input_method": "stdin",
   "parameters": {
     "action": {
-      "description": "The operation (start, stop, restart, enable, disable, status) to perform on the service",
+      "description": "The operation (start, stop, restart, enable, disable, status) to perform on the service.",
       "type": "Enum[start, stop, restart, enable, disable, status]"
     },
     "name": {
@@ -11,8 +11,13 @@
       "type": "String[1]"
     },
     "provider": {
-      "description": "The provider to use to manage or inspect the service, defaults to the system service manager",
+      "description": "The provider to use to manage or inspect the service, defaults to the system service manager. Only used when the 'puppet-agent' feature is available on the target so we can leverage Puppet.",
       "type": "Optional[String[1]]"
     }
-  }
+  },
+  "implementations": [
+    {"name": "init.rb", "requirements": ["puppet-agent"]},
+    {"name": "windows.ps1", "requirements": ["powershell"], "input_method": "powershell"},
+    {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment"}
+  ]
 }

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,5 +1,6 @@
 {
   "description": "Manage the state of services (without a puppet agent)",
+  "private": true,
   "input_method": "environment",
   "parameters": {
     "action": {

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -1,5 +1,6 @@
 {
   "description": "Manage the state of Windows services (without a puppet agent)",
+  "private": true,
   "input_method": "powershell",
   "parameters": {
     "action": {


### PR DESCRIPTION
Add implementations to the init task so it falls back to non-Ruby
implementations when puppet-agent isn't available. Also hide the extra
implementations from task runners that implement private tasks and task
implementations.