### PR TITLE
(MODULES-8420) Move to GEM_BOLT pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ rvm:
   - 2.5.1
 env:
   global:
-    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
+    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0" GEM_BOLT=true
 matrix:
   fast_finish: true
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,9 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-win-system-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "bolt", '~> 1.4',                               require: false
+  if ENV['GEM_BOLT']
+    gem 'bolt', '~> 1.4', require: false
+  end
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
Bolt is dependent on puppet 6. The jenkins agents that run the CJC job to ship to the forge have puppet5. A pattern in modules that require bolt for testing has been established to only require bolt when the environment variable GEM_BOLT is set.