### PR TITLE
(MODULES-8420) Merge back release branch to include change for 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [0.5.0](https://github.com/puppetlabs/puppetlabs-service/tree/0.5.0) (2019-01-07)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-service/compare/0.4.0...0.5.0)
+
+### Fixed
+
+- pdksync - \(FM-7655\) Fix rubygems-update for ruby \< 2.3 [\#62](https://github.com/puppetlabs/puppetlabs-service/pull/62) ([tphoney](https://github.com/tphoney))
+
+### Added
+
+- \(MODULES-8391\) Enable implementations on the init task and hide others [\#61](https://github.com/puppetlabs/puppetlabs-service/pull/61) ([MikaelSmith](https://github.com/MikaelSmith))
+
 ## [0.4.0](https://github.com/puppetlabs/puppetlabs-service/tree/0.4.0) (2018-09-28)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-service/compare/0.3.1...0.4.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-service",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "puppetlabs",
   "summary": "Tasks that manipulate a service",
   "license": "Apache-2.0",


### PR DESCRIPTION
After the release prep commit to the release branch but before shipping the module a new/critical change was committed to master in order to push release to forge. This commit merges back the release prep commit to master. Will update the changelog and re-target updates at release branch.