### PR TITLE
(MODULES-8456) Do not use custom rake task for test invocation

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,10 +5,11 @@
     - set: docker/ubuntu-14.04
   docker_defaults:
     bundler_args: ""
-    script: bundle exec rake task_acceptance
+    script: bundle exec rake beaker
   secure: ""
   global_env:
-    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0" GEM_BOLT=true
+    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
+    - GEM_BOLT=true
   branches:
     - release
   remove_includes:
@@ -41,5 +42,12 @@ Gemfile:
   unmanaged: true
 
 Rakefile:
-  extras:
-    - 'task :task_acceptance => [:spec_prep, :beaker]'
+  extras: |
+    # The beaker task requires the test fixtures created by the spec_prep task
+    beaker_task_exists = Rake::Task.task_defined?('beaker')
+    spec_prep_task_exists = Rake::Task.task_defined?('spec_prep')
+    if beaker_task_exists && spec_prep_task_exists
+      beaker_task = Rake::Task['beaker']
+      spec_prep =  Rake::Task['spec_prep']
+      beaker_task.enhance(beaker_task.prerequisite_tasks << spec_prep)
+    end

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
 env:
   global:
     - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
-    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0" GEM_BOLT=true
+    - GEM_BOLT=true
 matrix:
   fast_finish: true
   include:
@@ -25,7 +25,7 @@ matrix:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/centos-7 BEAKER_TESTMODE=apply
       rvm: 2.5.1
-      script: bundle exec rake task_acceptance
+      script: bundle exec rake beaker
       services: docker
       sudo: required
     -
@@ -33,7 +33,7 @@ matrix:
       dist: trusty
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/ubuntu-14.04 BEAKER_TESTMODE=apply
       rvm: 2.5.1
-      script: bundle exec rake task_acceptance
+      script: bundle exec rake beaker
       services: docker
       sudo: required
     -

--- a/Rakefile
+++ b/Rakefile
@@ -74,4 +74,12 @@ EOM
   end
 end
 
-task :task_acceptance => [:spec_prep, :beaker]
+# The beaker task requires the test fixtures created by the spec_prep task
+beaker_task_exists = Rake::Task.task_defined?('beaker')
+spec_prep_task_exists = Rake::Task.task_defined?('spec_prep')
+if beaker_task_exists && spec_prep_task_exists
+  beaker_task = Rake::Task['beaker']
+  spec_prep =  Rake::Task['spec_prep']
+  beaker_task.enhance(beaker_task.prerequisite_tasks << spec_prep)
+end
+


### PR DESCRIPTION
This commit changes the rake task acceptance test invocation from `task_acceptance` to the "default" `beaker` to avoid having "special cases" in CI.