### PR TITLE
(BOLT-1103) Rewrite and fix status output

### DIFF
--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -35,7 +35,7 @@ describe 'linux service task', unless: fact('osfamily') == 'windows' do
     it "stop #{package_to_use}" do
       result = run('action' => 'stop', 'name' => package_to_use)
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{stop})
+      expect(result[0]['result']['status']).to match(%r{ActiveState=inactive|stop})
     end
   end
 
@@ -43,7 +43,7 @@ describe 'linux service task', unless: fact('osfamily') == 'windows' do
     it "start #{package_to_use}" do
       result = run('action' => 'start', 'name' => package_to_use)
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{start})
+      expect(result[0]['result']['status']).to match(%r{ActiveState=active|running})
     end
   end
 
@@ -51,7 +51,7 @@ describe 'linux service task', unless: fact('osfamily') == 'windows' do
     it "restart #{package_to_use}" do
       result = run('action' => 'restart', 'name' => package_to_use)
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{restart})
+      expect(result[0]['result']['status']).to match(%r{ActiveState=active|running})
     end
   end
 end

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,11 +1,11 @@
 {
-  "description": "Manage the state of services (without a puppet agent)",
+  "description": "Manage and inspect the state of services (without a puppet agent)",
   "private": true,
   "input_method": "environment",
   "parameters": {
     "action": {
-      "description": "The operation (start, stop) to perform on the service",
-      "type": "Enum[start, stop, restart]"
+      "description": "The operation (start, stop, restart, enable, disable, status) to perform on the service.",
+      "type": "Enum[start, stop, restart, enable, disable, status]"
     },
     "name": {
       "description": "The name of the service to operate on.",

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -1,45 +1,79 @@
 #!/bin/bash
 
-action="$PT_action"
-name="$PT_name"
-service_managers[0]="systemctl"
-service_managers[1]="service"
-service_managers[2]="initctl"
+# example cli /opt/puppetlabs/puppet/bin/bolt  task run service::linux action=stop name=ntp --nodes localhost --modulepath /etc/ puppetlabs/code/modules --password puppet --user root
 
-# example cli /opt/puppetlabs/puppet/bin/bolt  task run service::linux action=stop name=ntp --nodes localhost --modulepath /etc/puppetlabs/code/modules --password puppet --user root
+# Exit with an error message and error code, defaulting to 1
+fail() {
+  # Print a message: entry if there were anything printed to stderr
+  if [[ -s $_tmp ]]; then
+    # Hack to try and output valid json by replacing newlines with spaces.
+    echo "{ \"status\": \"error\", \"message\": \"$(tr '\n' ' ' <$_tmp)\" }"
+  else
+    echo '{ "status": "error" }'
+  fi
 
-check_command_exists() {
-  (which "$1") > /dev/null 2>&1
-  command_exists=$?
-  return $command_exists
+  exit ${2:-1}
 }
 
-for service_manager in "${service_managers[@]}"
-do
-  check_command_exists "$service_manager"
-  command_exists=$?
-  if [ $command_exists -eq 0 ]; then
-    command_line="$service_manager $action $name"
-    if [ $service_manager == "service" ]; then
-      command_line="$service_manager $name $action"
-    fi
-    output=$($command_line 2>&1)
-    status_from_command=$?
-    # set up our status and exit code
-    if [ $status_from_command -eq 0 ]; then
-      echo "{ \"status\": \"$name $action\" }"
-      exit 0
-    else
-      # initd is special, starting an already started service is an error
-      if [[ $service_manager == "service" && "$output" == *"Job is already running"* ]]; then
-        echo "{ \"status\": \"$name $action\" }"
-        exit 0
-      fi
-      echo "{ \"status\": \"unable to run command '$command_line'\" }"
-      exit $status_from_command
-    fi
+success() {
+  echo "$1"
+  exit 0
+}
+
+# Keep stderr in a temp file.  Easier than `tee` or capturing process substitutions
+_tmp="$(mktemp)"
+exec 2>"$_tmp"
+
+action="$PT_action"
+name="$PT_name"
+service_managers=("systemctl" "service" "initctl")
+
+for s in "${service_managers[@]}"; do
+  if type "$s" &>/dev/null; then
+    available_manager="$s"
+    break
   fi
 done
 
-echo "{ \"status\": \"No service managers found\" }"
-exit 255
+[[ $available_manager ]] || {
+  echo '{ "status": "No service managers found" }'
+  exit 255
+}
+
+# For any service manager, check if the action is "status". If so, only run a status command
+# Otherwise, run the requested action and follow up with a "status" command
+case "$available_manager" in
+  "systemctl")
+    if [[ $action != "status" ]]; then
+      "$s" "$action" "$name" || fail
+    fi
+
+    # `systemctl show` is the command to use in scripts.  Use it to get the pid, load, and active states
+    # sample output: "MainPID=23377,LoadState=loaded,ActiveState=active"
+    cmd_out="$("$s" "show" "$name" -p LoadState -p MainPID -p ActiveState --no-pager | paste -sd ',' -)"
+    success "{ \"status\": \"${cmd_out}\" }"
+    ;;
+
+  # These commands seem to only differ slightly in their invocation
+  "service"|"initctl")
+    if [[ $s == "service" ]]; then
+      cmd=("$s" "$name" "$action")
+      cmd_status=("$s" "$name" "status")
+    else
+      cmd=("$s" "$action" "$name")
+      cmd_status=("$s" "status" "$name")
+    fi
+
+    if [[ $action != "status" ]]; then
+      # service and initctl may return non-zero if the service is already started or stopped
+      # If so, check for either "already running" or "Unknown instance" in the output before failing
+      "${cmd[@]}" >/dev/null || {
+        grep -q "Job is already running" "$_tmp" || grep -q "Unknown instance:" "$_tmp" || fail
+      }
+
+    fi
+
+    # "status" is already pretty terse for these commands
+    cmd_out="$("${cmd_status[@]}")"
+    success "{ \"status\": \"${cmd_out}\" }"
+esac


### PR DESCRIPTION
Return information from the service command itself, i.e. systemctl,
service, or initctl.  Also provide the error message as part of the json
object.  Directly check the return code of commands instead of storing
$? in a variable when we can.  Use mktmp and exec to manage stderr.