### PR TITLE
Fix service control with PowerShell 2.0

### DIFF
--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -23,16 +23,16 @@ function Invoke-ServiceAction($Service, $Action)
     'start'
     {
       if ($Service.Status -eq 'Running') { $status = $InSyncStatus }
-      else { Start-Service $Service }
+      else { $Service | Start-Service }
     }
     'stop'
     {
       if ($Service.Status -eq 'Stopped') { $status = $InSyncStatus }
-      else { Stop-Service $Service }
+      else { $Service | Stop-Service }
     }
     'restart'
     {
-      Restart-Service $Service
+      $Service | Restart-Service
       $status = 'restarted'
     }
     # no-op since status always returned


### PR DESCRIPTION
There seems to be a problem with the -InputObject parameter in PowerShell 2.0 on Windows Server 2008 R2. 

```
PS C:\Users\{USERNAME}\Desktop> Stop-Service (Get-Service puppet)
Stop-Service : Cannot find any service with service name 'System.ServiceProcess.ServiceController'.
At line:1 char:13
+ Stop-Service <<<< (Get-Service puppet)
+ CategoryInfo : ObjectNotFound: (System.ServiceProcess.ServiceController:String) [Stop-Service], Service
CommandException
+ FullyQualifiedErrorId : NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.StopServiceCommand
PS C:\Users\{USERNAME}\Desktop> (Get-Service puppet) | Stop-Service
```

This issue was reproduced on two fully isolated environments. Piping the service object to Start/Stop/Restart-Service fixes the issue.

@steinbrueckri @PaddySkyhit @gleichdavid