### PR TITLE
(BOLT-1103) Unify output of task implementations

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -42,7 +42,7 @@ Gemfile:
           - mingw
           - x64_mingw
       - gem: bolt
-        version: '~> 1.3'
+        version: '~> 1.15'
         condition: ENV['GEM_BOLT']
 
 Rakefile:

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-win-system-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "bolt", '~> 1.3',                               require: false if ENV['GEM_BOLT']
+  gem "bolt", "~> 1.15",                              require: false if ENV['GEM_BOLT']
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -22,40 +22,40 @@ describe 'service task' do
   describe 'enable action' do
     it 'enable/status a service' do
       result = task_run('service', 'action' => 'enable', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{in_sync|enabled})
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{in_sync|enabled})
 
       result = task_run('service', 'action' => 'status', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['enabled']).to eq('true')
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('enabled' => 'true')
     end
   end
 
   describe 'restart action' do
     it 'restart/status a service' do
       result = task_run('service', 'action' => 'restart', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to eq('restarted')
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => 'restarted')
 
       result = task_run('service', 'action' => 'status', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to eq('running')
-      expect(result[0]['result']['enabled']).to eq('true')
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => 'running')
+      expect(result[0]['result']).to include('enabled' => 'true')
     end
   end
 
   describe 'stop action' do
     it 'stop/status a service' do
       result = task_run('service', 'action' => 'stop', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{in_sync|stopped})
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{in_sync|stopped})
 
       # Debian can give incorrect status
       unless ['debian', 'ubuntu'].include?(os[:family])
         result = task_run('service', 'action' => 'status', 'name' => package_to_use)
-        expect(result[0]['status']).to eq('success')
-        expect(result[0]['result']['status']).to eq('stopped')
-        expect(result[0]['result']['enabled']).to eq('true')
+        expect(result[0]).to include('status' => 'success')
+        expect(result[0]['result']).to include('status' => 'stopped')
+        expect(result[0]['result']).to include('enabled' => 'true')
       end
     end
   end
@@ -63,15 +63,15 @@ describe 'service task' do
   describe 'start action' do
     it 'start/status a service' do
       result = task_run('service', 'action' => 'start', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{in_sync|started})
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{in_sync|started})
 
       # Debian can give incorrect status
       if os[:family] != 'debian'
         result = task_run('service', 'action' => 'status', 'name' => package_to_use)
-        expect(result[0]['status']).to eq('success')
-        expect(result[0]['result']['status']).to eq('running')
-        expect(result[0]['result']['enabled']).to eq('true')
+        expect(result[0]).to include('status' => 'success')
+        expect(result[0]['result']).to include('status' => 'running')
+        expect(result[0]['result']).to include('enabled' => 'true')
       end
     end
   end
@@ -79,12 +79,12 @@ describe 'service task' do
   describe 'disable action' do
     it 'disable/status a service' do
       result = task_run('service', 'action' => 'disable', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to eq('disabled')
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => 'disabled')
 
       result = task_run('service', 'action' => 'status', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['enabled']).to eq('false')
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('enabled' => 'false')
     end
   end
 end

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -2,27 +2,39 @@
 require 'spec_helper_acceptance'
 
 describe 'service task' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  def bolt_config
+    { 'modulepath' => RSpec.configuration.module_path }
+  end
+
+  let(:bolt_inventory) { hosts_to_inventory.merge('features' => ['puppet-agent']) }
+
   package_to_use = ''
   before(:all) do
+    options = { inventory: hosts_to_inventory.merge('features' => ['puppet-agent']) }
     if os[:family] != 'windows'
       if os[:family] == 'redhat' && os[:release].to_i < 6
-        task_run('service', 'action' => 'stop', 'name' => 'syslog')
+        params = { 'action' => 'stop', 'name' => 'syslog' }
+        run_task('service', 'default', params, options)
       end
       package_to_use = 'rsyslog'
       apply_manifest_on(default, "package { \"#{package_to_use}\": ensure => present, }")
     else
       package_to_use = 'W32Time'
-      task_run('service', 'action' => 'start', 'name' => package_to_use)
+      params = { 'action' => 'start', 'name' => package_to_use }
+      run_task('service', 'default', params, options)
     end
   end
 
   describe 'enable action' do
     it 'enable/status a service' do
-      result = task_run('service', 'action' => 'enable', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'enable', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => %r{in_sync|enabled})
 
-      result = task_run('service', 'action' => 'status', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('enabled' => 'true')
     end
@@ -30,11 +42,11 @@ describe 'service task' do
 
   describe 'restart action' do
     it 'restart/status a service' do
-      result = task_run('service', 'action' => 'restart', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'restart', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'restarted')
 
-      result = task_run('service', 'action' => 'status', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'running')
       expect(result[0]['result']).to include('enabled' => 'true')
@@ -43,13 +55,13 @@ describe 'service task' do
 
   describe 'stop action' do
     it 'stop/status a service' do
-      result = task_run('service', 'action' => 'stop', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'stop', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => %r{in_sync|stopped})
 
       # Debian can give incorrect status
       unless ['debian', 'ubuntu'].include?(os[:family])
-        result = task_run('service', 'action' => 'status', 'name' => package_to_use)
+        result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']).to include('status' => 'stopped')
         expect(result[0]['result']).to include('enabled' => 'true')
@@ -59,13 +71,13 @@ describe 'service task' do
 
   describe 'start action' do
     it 'start/status a service' do
-      result = task_run('service', 'action' => 'start', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'start', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => %r{in_sync|started})
 
       # Debian can give incorrect status
       if os[:family] != 'debian'
-        result = task_run('service', 'action' => 'status', 'name' => package_to_use)
+        result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']).to include('status' => 'running')
         expect(result[0]['result']).to include('enabled' => 'true')
@@ -75,11 +87,11 @@ describe 'service task' do
 
   describe 'disable action' do
     it 'disable/status a service' do
-      result = task_run('service', 'action' => 'disable', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'disable', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'disabled')
 
-      result = task_run('service', 'action' => 'status', 'name' => package_to_use)
+      result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('enabled' => 'false')
     end

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -2,9 +2,6 @@
 require 'spec_helper_acceptance'
 
 describe 'service task' do
-  include Beaker::TaskHelper::Inventory
-  include BoltSpec::Run
-
   package_to_use = ''
   before(:all) do
     if os[:family] != 'windows'

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -2,9 +2,6 @@
 require 'spec_helper_acceptance'
 
 describe 'linux service task', unless: os[:family] == 'windows' do
-  include Beaker::TaskHelper::Inventory
-  include BoltSpec::Run
-
   package_to_use = 'rsyslog'
   before(:all) do
     if os[:family] == 'redhat' && os[:release].to_i < 6

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -17,7 +17,7 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     it "stop #{package_to_use}" do
       result = task_run('service::linux', 'action' => 'stop', 'name' => package_to_use)
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{stop})
+      expect(result[0]['result']['status']).to match(%r{ActiveState=inactive|stop})
     end
   end
 
@@ -25,7 +25,7 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     it "start #{package_to_use}" do
       result = task_run('service::linux', 'action' => 'start', 'name' => package_to_use)
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{start})
+      expect(result[0]['result']['status']).to match(%r{ActiveState=active|running})
     end
   end
 
@@ -33,7 +33,7 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     it "restart #{package_to_use}" do
       result = task_run('service::linux', 'action' => 'restart', 'name' => package_to_use)
       expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{restart})
+      expect(result[0]['result']['status']).to match(%r{ActiveState=active|running})
     end
   end
 end

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -34,12 +34,28 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     end
   end
 
-  describe 'status action' do
-    it "status #{package_to_use}" do
-      result = task_run('service::linux', 'action' => 'status', 'name' => package_to_use)
-      expect(result[0]).to include('status' => 'success')
-      expect(result[0]['result']).to include('status' => %r{ActiveState=active|running})
-      expect(result[0]['result']).to include('enabled')
+  context 'when puppet-agent feature not available on target' do
+    let(:config) { { 'modulepath' => RSpec.configuration.module_path } }
+    let(:inventory) { hosts_to_inventory }
+
+    it 'enable action fails' do
+      params = { 'action' => 'enable', 'name' => package_to_use }
+      result = run_task('service', 'default', params, config: config, inventory: inventory)
+      expect(result[0]).to include('status' => 'failure')
+      expect(result[0]['result']).to include('status' => 'failure')
+      expect(result[0]['result']['_error']).to include('msg' => %r{'enable' action not supported})
+      expect(result[0]['result']['_error']).to include('kind' => 'bash-error')
+      expect(result[0]['result']['_error']).to include('details')
+    end
+
+    it 'disable action fails' do
+      params = { 'action' => 'disable', 'name' => package_to_use }
+      result = run_task('service', 'default', params, config: config, inventory: inventory)
+      expect(result[0]).to include('status' => 'failure')
+      expect(result[0]['result']).to include('status' => 'failure')
+      expect(result[0]['result']['_error']).to include('msg' => %r{'disable' action not supported})
+      expect(result[0]['result']['_error']).to include('kind' => 'bash-error')
+      expect(result[0]['result']['_error']).to include('details')
     end
   end
 end

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -16,24 +16,33 @@ describe 'linux service task', unless: os[:family] == 'windows' do
   describe 'stop action' do
     it "stop #{package_to_use}" do
       result = task_run('service::linux', 'action' => 'stop', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{ActiveState=inactive|stop})
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{ActiveState=inactive|stop})
     end
   end
 
   describe 'start action' do
     it "start #{package_to_use}" do
       result = task_run('service::linux', 'action' => 'start', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{ActiveState=active|running})
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{ActiveState=active|running})
     end
   end
 
   describe 'restart action' do
     it "restart #{package_to_use}" do
       result = task_run('service::linux', 'action' => 'restart', 'name' => package_to_use)
-      expect(result[0]['status']).to eq('success')
-      expect(result[0]['result']['status']).to match(%r{ActiveState=active|running})
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{ActiveState=active|running})
+    end
+  end
+
+  describe 'status action' do
+    it "status #{package_to_use}" do
+      result = task_run('service::linux', 'action' => 'status', 'name' => package_to_use)
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{ActiveState=active|running})
+      expect(result[0]['result']).to include('enabled')
     end
   end
 end

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -2,17 +2,28 @@
 require 'spec_helper_acceptance'
 
 describe 'linux service task', unless: os[:family] == 'windows' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  def bolt_config
+    { 'modulepath' => RSpec.configuration.module_path }
+  end
+
+  let(:bolt_inventory) { hosts_to_inventory.merge('features' => ['puppet-agent']) }
+
   package_to_use = 'rsyslog'
   before(:all) do
     if os[:family] == 'redhat' && os[:release].to_i < 6
-      task_run('service::linux', 'action' => 'stop', 'name' => 'syslog')
+      options = { inventory: hosts_to_inventory.merge('features' => ['puppet-agent']) }
+      params = { 'action' => 'stop', 'name' => 'syslog' }
+      run_task('service::linux', 'default', params, options)
     end
     apply_manifest_on(default, "package { \"#{package_to_use}\": ensure => present, }")
   end
 
   describe 'stop action' do
     it "stop #{package_to_use}" do
-      result = task_run('service::linux', 'action' => 'stop', 'name' => package_to_use)
+      result = run_task('service::linux', 'default', 'action' => 'stop', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => %r{ActiveState=inactive|stop})
     end
@@ -20,7 +31,7 @@ describe 'linux service task', unless: os[:family] == 'windows' do
 
   describe 'start action' do
     it "start #{package_to_use}" do
-      result = task_run('service::linux', 'action' => 'start', 'name' => package_to_use)
+      result = run_task('service::linux', 'default', 'action' => 'start', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => %r{ActiveState=active|running})
     end
@@ -28,19 +39,18 @@ describe 'linux service task', unless: os[:family] == 'windows' do
 
   describe 'restart action' do
     it "restart #{package_to_use}" do
-      result = task_run('service::linux', 'action' => 'restart', 'name' => package_to_use)
+      result = run_task('service::linux', 'default', 'action' => 'restart', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => %r{ActiveState=active|running})
     end
   end
 
   context 'when puppet-agent feature not available on target' do
-    let(:config) { { 'modulepath' => RSpec.configuration.module_path } }
-    let(:inventory) { hosts_to_inventory }
+    let(:bolt_inventory) { hosts_to_inventory }
 
     it 'enable action fails' do
       params = { 'action' => 'enable', 'name' => package_to_use }
-      result = run_task('service', 'default', params, config: config, inventory: inventory)
+      result = run_task('service', 'default', params)
       expect(result[0]).to include('status' => 'failure')
       expect(result[0]['result']).to include('status' => 'failure')
       expect(result[0]['result']['_error']).to include('msg' => %r{'enable' action not supported})
@@ -50,7 +60,7 @@ describe 'linux service task', unless: os[:family] == 'windows' do
 
     it 'disable action fails' do
       params = { 'action' => 'disable', 'name' => package_to_use }
-      result = run_task('service', 'default', params, config: config, inventory: inventory)
+      result = run_task('service', 'default', params)
       expect(result[0]).to include('status' => 'failure')
       expect(result[0]['result']).to include('status' => 'failure')
       expect(result[0]['result']['_error']).to include('msg' => %r{'disable' action not supported})

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -35,4 +35,29 @@ describe 'windows service task', if: os[:family] == 'windows' do
       expect(result[0]['result']).to include('enabled')
     end
   end
+
+  context 'when puppet-agent feature not available on target' do
+    let(:config) { { 'modulepath' => RSpec.configuration.module_path } }
+    let(:inventory) { hosts_to_inventory }
+
+    it 'enable action fails' do
+      params = { 'action' => 'enable', 'name' => package_to_use }
+      result = run_task('service', 'default', params, config: config, inventory: inventory)
+      expect(result[0]).to include('status' => 'failure')
+      expect(result[0]['result']).to include('status' => 'failure')
+      expect(result[0]['result']['_error']).to include('msg' => %r{'enable' action not supported})
+      expect(result[0]['result']['_error']).to include('kind' => 'powershell_error')
+      expect(result[0]['result']['_error']).to include('details')
+    end
+
+    it 'disable action fails' do
+      params = { 'action' => 'disable', 'name' => package_to_use }
+      result = run_task('service', 'default', params, config: config, inventory: inventory)
+      expect(result[0]).to include('status' => 'failure')
+      expect(result[0]['result']).to include('status' => 'failure')
+      expect(result[0]['result']['_error']).to include('msg' => %r{'disable' action not supported})
+      expect(result[0]['result']['_error']).to include('kind' => 'powershell_error')
+      expect(result[0]['result']['_error']).to include('details')
+    end
+  end
 end

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -19,7 +19,7 @@ describe 'windows service task', if: fact('osfamily') == 'windows' do
     it "stop #{package_to_use}" do
       result = run('action' => 'stop', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
-      expect(result[0]['result']).to include('status' => %r{Stopped})
+      expect(result[0]['result']).to include('status' => 'Stopped')
     end
   end
 
@@ -27,7 +27,7 @@ describe 'windows service task', if: fact('osfamily') == 'windows' do
     it "start #{package_to_use}" do
       result = run('action' => 'start', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
-      expect(result[0]['result']).to include('status' => %r{started})
+      expect(result[0]['result']).to include('status' => 'Started')
     end
   end
 
@@ -35,7 +35,7 @@ describe 'windows service task', if: fact('osfamily') == 'windows' do
     it "restart #{package_to_use}" do
       result = run('action' => 'restart', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
-      expect(result[0]['result']).to include('status' => %r{restarted})
+      expect(result[0]['result']).to include('status' => 'Restarted')
     end
   end
 
@@ -43,8 +43,8 @@ describe 'windows service task', if: fact('osfamily') == 'windows' do
     it "status #{package_to_use}" do
       result = run('action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
-      expect(result[0]['result']).to include('status' => %r{started})
-      expect(result[0]['result']).to include('enabled' => 'Automatic')
+      expect(result[0]['result']).to include('status' => 'Started')
+      expect(result[0]['result']).to include('enabled')
     end
   end
 end

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -1,0 +1,50 @@
+# run a test task
+require 'spec_helper_acceptance'
+
+describe 'windows service task', if: fact('osfamily') == 'windows' do
+  include Beaker::TaskHelper::Inventory
+  include BoltSpec::Run
+
+  let(:module_path) { RSpec.configuration.module_path }
+  let(:config) { { 'modulepath' => module_path } }
+  let(:inventory) { hosts_to_inventory }
+
+  def run(params)
+    run_task('service::windows', 'default', params, config: config, inventory: inventory)
+  end
+
+  package_to_use = 'Spooler'
+
+  describe 'stop action' do
+    it "stop #{package_to_use}" do
+      result = run('action' => 'stop', 'name' => package_to_use)
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{Stopped})
+    end
+  end
+
+  describe 'start action' do
+    it "start #{package_to_use}" do
+      result = run('action' => 'start', 'name' => package_to_use)
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{started})
+    end
+  end
+
+  describe 'restart action' do
+    it "restart #{package_to_use}" do
+      result = run('action' => 'restart', 'name' => package_to_use)
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{restarted})
+    end
+  end
+
+  describe 'status action' do
+    it "status #{package_to_use}" do
+      result = run('action' => 'status', 'name' => package_to_use)
+      expect(result[0]).to include('status' => 'success')
+      expect(result[0]['result']).to include('status' => %r{started})
+      expect(result[0]['result']).to include('enabled' => 'Automatic')
+    end
+  end
+end

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -1,23 +1,11 @@
 # run a test task
 require 'spec_helper_acceptance'
 
-describe 'windows service task', if: fact('osfamily') == 'windows' do
-  include Beaker::TaskHelper::Inventory
-  include BoltSpec::Run
-
-  let(:module_path) { RSpec.configuration.module_path }
-  let(:config) { { 'modulepath' => module_path } }
-  let(:inventory) { hosts_to_inventory }
-
-  def run(params)
-    run_task('service::windows', 'default', params, config: config, inventory: inventory)
-  end
-
+describe 'windows service task', if: os[:family] == 'windows' do
   package_to_use = 'Spooler'
-
   describe 'stop action' do
     it "stop #{package_to_use}" do
-      result = run('action' => 'stop', 'name' => package_to_use)
+      result = task_run('service::windows', 'action' => 'stop', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'Stopped')
     end
@@ -25,7 +13,7 @@ describe 'windows service task', if: fact('osfamily') == 'windows' do
 
   describe 'start action' do
     it "start #{package_to_use}" do
-      result = run('action' => 'start', 'name' => package_to_use)
+      result = task_run('service::windows', 'action' => 'start', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'Started')
     end
@@ -33,7 +21,7 @@ describe 'windows service task', if: fact('osfamily') == 'windows' do
 
   describe 'restart action' do
     it "restart #{package_to_use}" do
-      result = run('action' => 'restart', 'name' => package_to_use)
+      result = task_run('service::windows', 'action' => 'restart', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'Restarted')
     end
@@ -41,7 +29,7 @@ describe 'windows service task', if: fact('osfamily') == 'windows' do
 
   describe 'status action' do
     it "status #{package_to_use}" do
-      result = run('action' => 'status', 'name' => package_to_use)
+      result = task_run('service::windows', 'action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'Started')
       expect(result[0]['result']).to include('enabled')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,6 +7,9 @@ require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 
+include Beaker::TaskHelper::Inventory
+include BoltSpec::Run
+
 run_puppet_install_helper
 configure_type_defaults_on(hosts)
 install_ca_certs

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,22 +7,11 @@ require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 
-include Beaker::TaskHelper::Inventory
-include BoltSpec::Run
-
 run_puppet_install_helper
 configure_type_defaults_on(hosts)
 install_ca_certs
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
-
-# Bolt helper task
-def task_run(task_name, params)
-  module_path = RSpec.configuration.module_path
-  config = { 'modulepath' => module_path }
-  inventory = hosts_to_inventory.merge('features' => ['puppet-agent'])
-  run_task(task_name, 'default', params, config: config, inventory: inventory)
-end
 
 RSpec.configure do |c|
   # Readable test descriptions

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -1,11 +1,11 @@
 {
-  "description": "Manage the state of services (without a puppet agent)",
+  "description": "Manage and inspect the state of services (without a puppet agent)",
   "private": true,
   "input_method": "environment",
   "parameters": {
     "action": {
-      "description": "The operation (start, stop) to perform on the service",
-      "type": "Enum[start, stop, restart]"
+      "description": "The operation (start, stop, restart, status) to perform on the service.",
+      "type": "Enum[start, stop, restart, status]"
     },
     "name": {
       "description": "The name of the service to operate on.",

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -1,45 +1,79 @@
 #!/bin/bash
 
-action="$PT_action"
-name="$PT_name"
-service_managers[0]="systemctl"
-service_managers[1]="service"
-service_managers[2]="initctl"
+# example cli /opt/puppetlabs/puppet/bin/bolt  task run service::linux action=stop name=ntp --nodes localhost --modulepath /etc/ puppetlabs/code/modules --password puppet --user root
 
-# example cli /opt/puppetlabs/puppet/bin/bolt  task run service::linux action=stop name=ntp --nodes localhost --modulepath /etc/puppetlabs/code/modules --password puppet --user root
+# Exit with an error message and error code, defaulting to 1
+fail() {
+  # Print a message: entry if there were anything printed to stderr
+  if [[ -s $_tmp ]]; then
+    # Hack to try and output valid json by replacing newlines with spaces.
+    echo "{ \"status\": \"error\", \"message\": \"$(tr '\n' ' ' <$_tmp)\" }"
+  else
+    echo '{ "status": "error" }'
+  fi
 
-check_command_exists() {
-  (which "$1") > /dev/null 2>&1
-  command_exists=$?
-  return $command_exists
+  exit ${2:-1}
 }
 
-for service_manager in "${service_managers[@]}"
-do
-  check_command_exists "$service_manager"
-  command_exists=$?
-  if [ $command_exists -eq 0 ]; then
-    command_line="$service_manager $action $name"
-    if [ $service_manager == "service" ]; then
-      command_line="$service_manager $name $action"
-    fi
-    output=$($command_line 2>&1)
-    status_from_command=$?
-    # set up our status and exit code
-    if [ $status_from_command -eq 0 ]; then
-      echo "{ \"status\": \"$name $action\" }"
-      exit 0
-    else
-      # initd is special, starting an already started service is an error
-      if [[ $service_manager == "service" && "$output" == *"Job is already running"* ]]; then
-        echo "{ \"status\": \"$name $action\" }"
-        exit 0
-      fi
-      echo "{ \"status\": \"unable to run command '$command_line'\" }"
-      exit $status_from_command
-    fi
+success() {
+  echo "$1"
+  exit 0
+}
+
+# Keep stderr in a temp file.  Easier than `tee` or capturing process substitutions
+_tmp="$(mktemp)"
+exec 2>"$_tmp"
+
+action="$PT_action"
+name="$PT_name"
+service_managers=("systemctl" "service" "initctl")
+
+for s in "${service_managers[@]}"; do
+  if type "$s" &>/dev/null; then
+    available_manager="$s"
+    break
   fi
 done
 
-echo "{ \"status\": \"No service managers found\" }"
-exit 255
+[[ $available_manager ]] || {
+  echo '{ "status": "No service managers found" }'
+  exit 255
+}
+
+# For any service manager, check if the action is "status". If so, only run a status command
+# Otherwise, run the requested action and follow up with a "status" command
+case "$available_manager" in
+  "systemctl")
+    if [[ $action != "status" ]]; then
+      "$s" "$action" "$name" || fail
+    fi
+
+    # `systemctl show` is the command to use in scripts.  Use it to get the pid, load, and active states
+    # sample output: "MainPID=23377,LoadState=loaded,ActiveState=active"
+    cmd_out="$("$s" "show" "$name" -p LoadState -p MainPID -p ActiveState --no-pager | paste -sd ',' -)"
+    success "{ \"status\": \"${cmd_out}\" }"
+    ;;
+
+  # These commands seem to only differ slightly in their invocation
+  "service"|"initctl")
+    if [[ $s == "service" ]]; then
+      cmd=("$s" "$name" "$action")
+      cmd_status=("$s" "$name" "status")
+    else
+      cmd=("$s" "$action" "$name")
+      cmd_status=("$s" "status" "$name")
+    fi
+
+    if [[ $action != "status" ]]; then
+      # service and initctl may return non-zero if the service is already started or stopped
+      # If so, check for either "already running" or "Unknown instance" in the output before failing
+      "${cmd[@]}" >/dev/null || {
+        grep -q "Job is already running" "$_tmp" || grep -q "Unknown instance:" "$_tmp" || fail
+      }
+
+    fi
+
+    # "status" is already pretty terse for these commands
+    cmd_out="$("${cmd_status[@]}")"
+    success "{ \"status\": \"${cmd_out}\" }"
+esac

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -7,11 +7,11 @@ fail() {
   # Print a message: entry if there were anything printed to stderr
   if [[ -s $_tmp ]]; then
     # Hack to try and output valid json by replacing newlines with spaces.
-    echo "{ \"status\": \"error\", \"message\": \"$(tr '\n' ' ' <$_tmp)\" }"
+    error_data="{ \"message\": \"$(tr '\n' ' ' <$_tmp)\", \"kind\": \"bash-error\", \"details\": {} }"
   else
-    echo '{ "status": "error" }'
+    error_data="{ \"message\": \"Task error\", \"kind\": \"bash-error\", \"details\": {} }"
   fi
-
+  echo "{ \"status\": \"failure\", \"_error\": $error_data }"
   exit ${2:-1}
 }
 

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -78,8 +78,6 @@ catch
   Write-Host @"
   {
     "status"  : "failure",
-    "name"    : "$Name",
-    "action"  : "$Action",
     "_error"  : {
       "msg" : "Unable to perform '$Action' on '$Name': $($_.Exception.Message)",
       "kind": "powershell_error",

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -23,17 +23,17 @@ function Invoke-ServiceAction($Service, $Action)
     'start'
     {
       if ($Service.Status -eq 'Running') { $status = $InSyncStatus }
-      else { Start-Service $Service }
+      else { Start-Service -inputObject $Service }
     }
     'stop'
     {
       if ($Service.Status -eq 'Stopped') { $status = $InSyncStatus }
-      else { Stop-Service $Service }
+      else { Stop-Service -inputObject $Service }
     }
     'restart'
     {
-      Restart-Service $Service
-      $status = 'restarted'
+      Restart-Service -inputObject $Service
+      $status = 'Restarted'
     }
     # no-op since status always returned
     'status' { }
@@ -42,10 +42,12 @@ function Invoke-ServiceAction($Service, $Action)
   # user action
   if ($status -eq $null)
   {
+    # For older systems this needs to be refreshed. Is there a cleaner way?
+    $refresh = Get-Service -Name $service.ServiceName
+    $status = $refresh.Status
     # https://msdn.microsoft.com/en-us/library/system.serviceprocess.servicecontrollerstatus(v=vs.110).aspx
     # ContinuePending, Paused, PausePending, Running, StartPending, Stopped, StopPending
-    $status = $Service.Status
-    if ($status -eq 'Running') { $status = 'started' }
+    if ($status -eq 'Running') { $status = 'Started' }
   }
 
   return $status

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -56,17 +56,22 @@ try
   $service = Get-Service -Name $Name
   $status = Invoke-ServiceAction -Service $service -Action $action
 
-# TODO: could use ConvertTo-Json, but that requires PS3
-# if embedding in literal, should make sure Name / Status doesn't need escaping
-Write-Host @"
+  # TODO: could use ConvertTo-Json, but that requires PS3
+  # if embedding in literal, should make sure Name / Status doesn't need escaping
+  if ($action -eq 'status') {
+    Write-Host @"
 {
-  "name"        : "$($service.Name)",
-  "action"      : "$Action",
-  "displayName" : "$($service.DisplayName)",
   "status"      : "$status",
-  "startType"   : "$($service.StartType)"
+  "enabled"   : "$($service.StartType)"
 }
 "@
+  } else {
+    Write-Host @"
+{
+  "status"      : "$status"
+}
+"@
+  }
 }
 catch
 {


### PR DESCRIPTION
Previously the different implementations would have different keys in the JSON output. This chunk of work fixes some of the issues with the linux and powershell implementations and standardizes the output based on the ruby implementation.