### PR TITLE
(SEN-796) Move extension metadata

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -19,5 +19,11 @@
     {"name": "init.rb", "requirements": ["puppet-agent"]},
     {"name": "windows.ps1", "requirements": ["powershell"], "input_method": "powershell"},
     {"name": "linux.sh", "requirements": ["shell"], "input_method": "environment"}
-  ]
+  ],
+  "extensions": {
+    "discovery": {
+      "friendlyName": "Manage service",
+      "type": ["host"]
+    }
+  }
 }

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -11,12 +11,5 @@
       "description": "The name of the service to operate on.",
       "type": "String[1]"
     }
-  },
-  "extensions": {
-    "discovery": {
-      "friendlyName": "Manage service on Linux",
-      "osFamily": "linux",
-      "type": ["host"]
-    }
   }
 }

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -11,12 +11,5 @@
       "description": "The short name of the Windows service to operate on.",
       "type": "String[1]"
     }
-  },
-  "extensions": {
-    "discovery": {
-      "friendlyName": "Manage service on Windows",
-      "osFamily": "windows",
-      "type": ["host"]
-    }
   }
 }


### PR DESCRIPTION
windows.json and linux.json are private tasks and won't be surfaced. For this reason the discovery extension metadata should only be added into the init.json file