### PR TITLE
(FM-8047) Add RedHat8 as supported OS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,8 @@
       "operatingsystemrelease": [
         "5",
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
This commit adds RedHat 8 to the list of supported operating systems.

Pending merge of puppetlabs/ci-job-configs#5909.