### PR TITLE
(MODULES-9230) Force Windows Service Action

### DIFF
--- a/tasks/init.json
+++ b/tasks/init.json
@@ -10,6 +10,10 @@
       "description": "The name of the service to operate on.",
       "type": "String[1]"
     },
+    "force": {
+      "description": "Force a Windows service to restart even if it has dependent services. This parameter is passed for Windows services only.",
+      "type": "Optional[Boolean]"
+    },
     "provider": {
       "description": "The provider to use to manage or inspect the service, defaults to the system service manager. Only used when the 'puppet-agent' feature is available on the target so we can leverage Puppet.",
       "type": "Optional[String[1]]"

--- a/tasks/windows.json
+++ b/tasks/windows.json
@@ -10,6 +10,10 @@
     "name": {
       "description": "The short name of the Windows service to operate on.",
       "type": "String[1]"
+    },
+    "force": {
+      "description": "Force the service to stop or restart, even if other services depend on it",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -7,7 +7,11 @@ param(
 
   [Parameter(Mandatory = $true)]
   [String]
-  $Action
+  $Action,
+
+  [Parameter(Mandatory = $false)]
+  [Switch]
+  $Force
 )
 
 function ErrorMessage($Action, $Name, $Message)
@@ -36,7 +40,7 @@ function ValidateParams
 
 $ErrorActionPreference = 'Stop'
 
-function Invoke-ServiceAction($Service, $Action)
+function Invoke-ServiceAction($Service, $Action, $Force)
 {
   $inSyncStatus = 'in_sync'
   $status = $null
@@ -51,11 +55,11 @@ function Invoke-ServiceAction($Service, $Action)
     'stop'
     {
       if ($Service.Status -eq 'Stopped') { $status = $InSyncStatus }
-      else { Stop-Service -inputObject $Service }
+      else { Stop-Service -inputObject $Service -Force:$Force }
     }
     'restart'
     {
-      Restart-Service -inputObject $Service
+      Restart-Service -inputObject $Service  -Force:$Force
       $status = 'Restarted'
     }
     # no-op since status always returned
@@ -80,7 +84,7 @@ try
 {
   ValidateParams -Action $action
   $service = Get-Service -Name $Name
-  $status = Invoke-ServiceAction -Service $service -Action $action
+  $status = Invoke-ServiceAction -Service $service -Action $action  -Force:$Force
 
   # TODO: could use ConvertTo-Json, but that requires PS3
   # if embedding in literal, should make sure Name / Status doesn't need escaping


### PR DESCRIPTION
Windows Services with dependencies cannot be restarted unless the -Force flag is
used. This change implements the orce parameter to allow passing that flag.