### PR TITLE
(maint) Update service task return to use "enable"

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -36,7 +36,7 @@ describe 'service task' do
 
       result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
-      expect(result[0]['result']).to include('enabled' => 'true')
+      expect(result[0]['result']).to include('enable' => 'true')
     end
   end
 
@@ -49,7 +49,7 @@ describe 'service task' do
       result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
       expect(result[0]['result']).to include('status' => 'running')
-      expect(result[0]['result']).to include('enabled' => 'true')
+      expect(result[0]['result']).to include('enable' => 'true')
     end
   end
 
@@ -64,7 +64,7 @@ describe 'service task' do
         result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']).to include('status' => 'stopped')
-        expect(result[0]['result']).to include('enabled' => 'true')
+        expect(result[0]['result']).to include('enable' => 'true')
       end
     end
   end
@@ -80,7 +80,7 @@ describe 'service task' do
         result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
         expect(result[0]).to include('status' => 'success')
         expect(result[0]['result']).to include('status' => 'running')
-        expect(result[0]['result']).to include('enabled' => 'true')
+        expect(result[0]['result']).to include('enable' => 'true')
       end
     end
   end
@@ -93,7 +93,7 @@ describe 'service task' do
 
       result = run_task('service', 'default', 'action' => 'status', 'name' => package_to_use)
       expect(result[0]).to include('status' => 'success')
-      expect(result[0]['result']).to include('enabled' => 'false')
+      expect(result[0]['result']).to include('enable' => 'false')
     end
   end
 end

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -27,7 +27,7 @@ def restart(provider)
 end
 
 def status(provider)
-  { status: provider.status, enabled: provider.enabled? }
+  { status: provider.status, enable: provider.enabled? }
 end
 
 def enable(provider)

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -69,7 +69,7 @@ case "$available_manager" in
       success "{ \"status\": \"${cmd_out}\" }"
     else
       enabled_out="$("$service" "is-enabled" "$name")"
-      success "{ \"status\": \"${cmd_out}\", \"enabled\": \"${enabled_out}\" }"
+      success "{ \"status\": \"${cmd_out}\", \"enable\": \"${enabled_out}\" }"
     fi
     ;;
 
@@ -100,5 +100,5 @@ case "$available_manager" in
 
     # "status" is already pretty terse for these commands
     cmd_out="$("${cmd_status[@]}")"
-    success "{ \"status\": \"${cmd_out}\", \"enabled\": \"${enabled_out}\" }"
+    success "{ \"status\": \"${cmd_out}\", \"enable\": \"${enabled_out}\" }"
 esac

--- a/tasks/windows.ps1
+++ b/tasks/windows.ps1
@@ -92,7 +92,7 @@ try
     Write-Host @"
 {
   "status"      : "$status",
-  "enabled"   : "$($service.StartType)"
+  "enable"   : "$($service.StartType)"
 }
 "@
   } else {


### PR DESCRIPTION
Since `puppet resource service <service_name>` settings are called
`ensure` and `enable`, i.e.
```
service { 'puppet':
  ensure => 'running',
  enable => 'true',
}
```
it would be nice to have the service task return similarly named
parameters. This would allow using the result of a `service` task call
within a Bolt plan to be used in an `apply` block. As it stands now, the
result of a `service` call with break in an apply block because
`enabled` is not a valid parameter, but `enable` is.