### PR TITLE
(FM-8342) Run all tests on localhost

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -18,6 +18,7 @@ describe 'service task' do
       apply_manifest("package { \"#{package_to_use}\": ensure => present, }")
     else
       package_to_use = 'W32Time'
+      params = { 'action' => 'enable', 'name' => package_to_use }
       params = { 'action' => 'start', 'name' => package_to_use }
       run_bolt_task('service', params)
     end

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -4,11 +4,10 @@ require 'spec_helper_acceptance'
 describe 'service task' do
   package_to_use = ''
   before(:all) do
-    unless ENV['TARGET_HOST'] == 'localhost'
-      inventory_hash = inventory_hash_from_inventory_file
-      add_feature_to_node(inventory_hash, 'puppet-agent', ENV['TARGET_HOST'])
-      write_to_inventory_file(inventory_hash, 'inventory.yaml')
-    end
+    inventory_hash = inventory_hash_from_inventory_file
+    target = targeting_localhost? ? 'litmus_localhost' : ENV['TARGET_HOST']
+    add_feature_to_node(inventory_hash, 'puppet-agent', target)
+    write_to_inventory_file(inventory_hash, 'inventory.yaml')
     if os[:family] != 'windows'
       package_to_use = if os[:family] == 'redhat'
                          'httpd'
@@ -19,6 +18,7 @@ describe 'service task' do
     else
       package_to_use = 'W32Time'
       params = { 'action' => 'enable', 'name' => package_to_use }
+      run_bolt_task('service', params)
       params = { 'action' => 'start', 'name' => package_to_use }
       run_bolt_task('service', params)
     end

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -40,15 +40,12 @@ describe 'linux service task', unless: os[:family] == 'windows' do
 
   context 'when puppet-agent feature not available on target' do
     before(:all) do
-      unless ENV['TARGET_HOST'] == 'localhost'
-        inventory_hash = inventory_hash_from_inventory_file
-        inventory_hash = remove_feature_from_node(inventory_hash, 'puppet-agent', ENV['TARGET_HOST'])
-        write_to_inventory_file(inventory_hash, 'inventory.yaml')
-      end
+      target = targeting_localhost? ? 'litmus_localhost' : ENV['TARGET_HOST']
+      inventory_hash = remove_feature_from_node(inventory_hash_from_inventory_file, 'puppet-agent', target)
+      write_to_inventory_file(inventory_hash, 'inventory.yaml')
     end
 
     it 'enable action fails' do
-      skip('Cannot mock inventory features during localhost acceptance testing') if ENV['TARGET_HOST'] == 'localhost'
       params = { 'action' => 'enable', 'name' => package_to_use }
       result = run_bolt_task('service', params, expect_failures: true)
       expect(result['result']).to include('status' => 'failure')
@@ -58,7 +55,6 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     end
 
     it 'disable action fails' do
-      skip('Cannot mock inventory features during localhost acceptance testing') if ENV['TARGET_HOST'] == 'localhost'
       params = { 'action' => 'disable', 'name' => package_to_use }
       result = run_bolt_task('service', params, expect_failures: true)
       expect(result['result']).to include('status' => 'failure')

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -2,7 +2,12 @@
 require 'spec_helper_acceptance'
 
 describe 'windows service task', if: os[:family] == 'windows' do
-  package_to_use = 'SessionEnv'
+  package_to_use = 'W32Time'
+
+  before(:all) do
+    # Ensure the service is enabled before interacting.
+    result = run_bolt_task('service', 'action' => 'enable', 'name' => package_to_use)
+  end
 
   describe 'stop action' do
     it "stop #{package_to_use}" do

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -6,7 +6,7 @@ describe 'windows service task', if: os[:family] == 'windows' do
 
   before(:all) do
     # Ensure the service is enabled before interacting.
-    result = run_bolt_task('service', 'action' => 'enable', 'name' => package_to_use)
+    run_bolt_task('service', 'action' => 'enable', 'name' => package_to_use)
   end
 
   describe 'stop action' do
@@ -44,15 +44,12 @@ describe 'windows service task', if: os[:family] == 'windows' do
 
   context 'when puppet-agent feature not available on target' do
     before(:all) do
-      unless ENV['TARGET_HOST'] == 'localhost'
-        inventory_hash = inventory_hash_from_inventory_file
-        inventory_hash = remove_feature_from_node(inventory_hash, 'puppet-agent', ENV['TARGET_HOST'])
-        write_to_inventory_file(inventory_hash, 'inventory.yaml')
-      end
+      target = targeting_localhost? ? 'litmus_localhost' : ENV['TARGET_HOST']
+      inventory_hash = remove_feature_from_node(inventory_hash_from_inventory_file, 'puppet-agent', target)
+      write_to_inventory_file(inventory_hash, 'inventory.yaml')
     end
 
     it 'enable action fails' do
-      skip('Cannot mock inventory features during localhost acceptance testing') if ENV['TARGET_HOST'] == 'localhost'
       params = { 'action' => 'enable', 'name' => package_to_use }
       result = run_bolt_task('service', params, expect_failures: true)
       expect(result['result']).to include('status' => 'failure')
@@ -62,7 +59,6 @@ describe 'windows service task', if: os[:family] == 'windows' do
     end
 
     it 'disable action fails' do
-      skip('Cannot mock inventory features during localhost acceptance testing') if ENV['TARGET_HOST'] == 'localhost'
       params = { 'action' => 'disable', 'name' => package_to_use }
       result = run_bolt_task('service', params, expect_failures: true)
       expect(result['result']).to include('status' => 'failure')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,8 +5,17 @@ require 'puppet_litmus'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 include PuppetLitmus
 
-if ENV['TARGET_HOST'].nil? || ENV['TARGET_HOST'] == 'localhost'
+if targeting_localhost?
   puts 'Running tests against this machine !'
+  if File.exist?('inventory.yaml')
+    inventory_hash = inventory_hash_from_inventory_file
+    unless target_in_inventory?(inventory_hash, 'litmus_localhost')
+      inventory_hash['groups'] = inventory_hash['groups'] | localhost_inventory_hash['groups']
+      write_to_inventory_file(inventory_hash, 'inventory.yaml')
+    end
+  else
+    write_to_inventory_file(localhost_inventory_hash, 'inventory.yaml')
+  end
   if Gem.win_platform?
     set :backend, :cmd
   else


### PR DESCRIPTION
This commit updates the spec_helper_acceptance to use the new helpers and features in litmus to be take advantage of the ability to mock features for localhost.

It also updates the test files to remove branching behavior for testing between localhost and remote hosts, as well as removing the now unneccessary skips.