### PR TITLE
(MODULES-9979) Fix empty return values in Linux task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       - bundle exec rake 'litmus:install_agent[puppet5]'
       - bundle exec rake litmus:install_module
       script:
-      - bundle exec rake litmus:acceptance:serial
+      - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
     -
@@ -44,7 +44,7 @@ matrix:
       - bundle exec rake 'litmus:install_agent[puppet6]'
       - bundle exec rake litmus:install_module
       script:
-      - bundle exec rake litmus:acceptance:serial
+      - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
     -
@@ -57,7 +57,7 @@ matrix:
       - bundle exec rake 'litmus:install_agent[puppet5]'
       - bundle exec rake litmus:install_module
       script:
-      - bundle exec rake litmus:acceptance:serial
+      - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
     -
@@ -70,7 +70,7 @@ matrix:
       - bundle exec rake 'litmus:install_agent[puppet6]'
       - bundle exec rake litmus:install_module
       script:
-      - bundle exec rake litmus:acceptance:serial
+      - bundle exec rake litmus:acceptance:parallel
       services: docker
       sudo: required
     -

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,8 @@ end
 
 ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
-
+#gem 'puppet_litmus', path: '/home/tp/workspace/puppet_litmus'
+ gem 'puppet_litmus', git: 'https://github.com/tphoney/puppet_litmus.git', branch: 'parallelogram', require: false, platforms: [:ruby, :mswin, :mingw, :x64_mingw] if ENV['PUPPET_GEM_VERSION'].nil? or ENV['PUPPET_GEM_VERSION'] !~ %r{ 5}  
 group :development do
   gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')

--- a/distelli-manifest.yml
+++ b/distelli-manifest.yml
@@ -13,7 +13,7 @@ team-modules/puppetlabs-service:
     - echo "--- MODULE INSTALLATION ---"
     - bundle exec rake litmus:install_module
     - echo "--- TESTS RUNNING ---"
-    - bundle exec rake litmus:acceptance:serial
+    - bundle exec rake litmus:acceptance:parallel
   AfterBuildSuccess:
     - source /opt/rh/rh-ruby25/enable
     - bundle exec rake litmus:tear_down

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -8,6 +8,8 @@ describe 'linux service task', unless: os[:family] == 'windows' do
                      'apache2'
                    end
 
+  temp_inventory_file = "#{ENV['TARGET_HOST']}.yaml"
+
   before(:all) do
     apply_manifest("package { \"#{package_to_use}\": ensure => present, }")
   end
@@ -42,12 +44,16 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     before(:all) do
       target = targeting_localhost? ? 'litmus_localhost' : ENV['TARGET_HOST']
       inventory_hash = remove_feature_from_node(inventory_hash_from_inventory_file, 'puppet-agent', target)
-      write_to_inventory_file(inventory_hash, 'inventory.yaml')
+      write_to_inventory_file(inventory_hash, temp_inventory_file)
+    end
+
+    after(:all) do
+      File.delete(temp_inventory_file) if File.exist?(temp_inventory_file)
     end
 
     it 'enable action fails' do
       params = { 'action' => 'enable', 'name' => package_to_use }
-      result = run_bolt_task('service', params, expect_failures: true)
+      result = run_bolt_task('service', params, expect_failures: true, inventory_file: temp_inventory_file)
       expect(result['result']).to include('status' => 'failure')
       expect(result['result']['_error']).to include('msg' => %r{'enable' action not supported})
       expect(result['result']['_error']).to include('kind' => 'bash-error')
@@ -56,7 +62,7 @@ describe 'linux service task', unless: os[:family] == 'windows' do
 
     it 'disable action fails' do
       params = { 'action' => 'disable', 'name' => package_to_use }
-      result = run_bolt_task('service', params, expect_failures: true)
+      result = run_bolt_task('service', params, expect_failures: true, inventory_file: temp_inventory_file)
       expect(result['result']).to include('status' => 'failure')
       expect(result['result']['_error']).to include('msg' => %r{'disable' action not supported})
       expect(result['result']['_error']).to include('kind' => 'bash-error')

--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -40,6 +40,19 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     end
   end
 
+  context 'when a service does not exist' do
+    let(:non_existent_service) { 'foo' }
+
+    it 'reports useful information for status' do
+      params = { 'action' => 'restart', 'name' => 'foo' }
+      result = run_bolt_task('service::linux', params, expect_failures: true)
+      expect(result['result']).to include('status' => 'failure')
+      expect(result['result']['_error']).to include('msg' => %r{#{non_existent_service}})
+      expect(result['result']['_error']).to include('kind' => 'bash-error')
+      expect(result['result']['_error']).to include('details')
+    end
+  end
+
   context 'when puppet-agent feature not available on target' do
     before(:all) do
       target = targeting_localhost? ? 'litmus_localhost' : ENV['TARGET_HOST']

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,17 +5,8 @@ require 'puppet_litmus'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 include PuppetLitmus
 
-if targeting_localhost?
+if ENV['TARGET_HOST'].nil? || ENV['TARGET_HOST'] == 'localhost'
   puts 'Running tests against this machine !'
-  if File.exist?('inventory.yaml')
-    inventory_hash = inventory_hash_from_inventory_file
-    unless target_in_inventory?(inventory_hash, 'litmus_localhost')
-      inventory_hash['groups'] = inventory_hash['groups'] | localhost_inventory_hash['groups']
-      write_to_inventory_file(inventory_hash, 'inventory.yaml')
-    end
-  else
-    write_to_inventory_file(localhost_inventory_hash, 'inventory.yaml')
-  end
   if Gem.win_platform?
     set :backend, :cmd
   else

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -6,7 +6,7 @@ declare PT__installdir
 source "$PT__installdir/service/files/common.sh"
 
 # Verify service manager is available
-service_managers=("systemctl" "service" "initctl")
+service_managers=("systemctl" "initctl" "service")
 
 for service in "${service_managers[@]}"; do
   if type "$service" &>/dev/null; then
@@ -30,7 +30,7 @@ esac
 case "$available_manager" in
   "systemctl")
     if [[ $action != "status" ]]; then
-      "$service" "$action" "$name" || fail
+      "$service" "$action" "$name" 2>"$_tmp" || fail
     fi
 
     # `systemctl show` is the command to use in scripts.  Use it to get the pid, load, and active states
@@ -40,37 +40,61 @@ case "$available_manager" in
     if [[ $action != "status" ]]; then
       success "{ \"status\": \"${cmd_out}\" }"
     else
-      enabled_out="$("$service" "is-enabled" "$name")"
+      enabled_out="$("$service" "is-enabled" "$name" 2>&1)"
       success "{ \"status\": \"${cmd_out}\", \"enabled\": \"${enabled_out}\" }"
     fi
     ;;
 
-  # These commands seem to only differ slightly in their invocation
-  "service"|"initctl")
-    if [[ $service == "service" ]]; then
-      cmd=("$service" "$name" "$action")
-      cmd_status=("$service" "$name" "status")
-      # The chkconfig output has 'interesting' spacing/tabs, use word splitting to have single spaces
-      word_split=($(chkconfig --list "$name"))
-      enabled_out="${word_split[@]}"
-    else
-      cmd=("$service" "$action" "$name")
-      cmd_status=("$service" "status" "$name")
-      enabled_out="$("$service" "show-config" "$name")"
-    fi
+  "initctl")
+    cmd=("$service" "$action" "$name")
+    cmd_status=("$service" "status" "$name")
+
+    # The initctl show-config output has 'interesting' spacing/tabs, use word splitting to have single spaces
+    word_split=($("$service" show-config "$name" 2>&1))
+    enabled_out="${word_split[@]}"
 
     if [[ $action != "status" ]]; then
       # service and initctl may return non-zero if the service is already started or stopped
-      # If so, check for either "already running" or "Unknown instance" in the output before failing
-      "${cmd[@]}" >/dev/null || {
-        grep -q "Job is already running" "$_tmp" || grep -q "Unknown instance:" "$_tmp" || fail
+      # If so, check for either "already running" or "Unknown instance" or "is not running" in the output before failing
+      "${cmd[@]}" &>"$_tmp" || {
+        grep -q "already running" "$_tmp" || grep -q "Unknown instance:" "$_tmp" || grep -q "is not running" "$_tmp" || fail
       }
 
-      cmd_out="$("${cmd_status[@]}")"
+      cmd_out="$("${cmd_status[@]}" 2>&1)"
       success "{ \"status\": \"${cmd_out}\" }"
     fi
 
     # "status" is already pretty terse for these commands
-    cmd_out="$("${cmd_status[@]}")"
+    cmd_out="$("${cmd_status[@]}" 2>&1)"
+    success "{ \"status\": \"${cmd_out}\", \"enabled\": \"${enabled_out}\" }"
+    ;;
+
+  "service")
+    cmd=("$service" "$name" "$action")
+    cmd_status=("$service" "$name" "status")
+
+    # Several possibilities: chkconfig may be installed, the service may be a SysV job, or it may have been converted to Upstart
+    # This is exactly why we have systemd now
+    if type chkconfig &>/dev/null; then
+      # The chkconfig output has 'interesting' spacing/tabs, use word splitting to have single spaces
+      word_split=($(chkconfig --list "$name" 2>&1))
+    else
+      word_split=($("$service" "$name" "show-config"  2>&1))
+    fi
+    enabled_out="${word_split[@]}"
+
+    if [[ $action != "status" ]]; then
+      # service and initctl may return non-zero if the service is already started or stopped
+      # If so, check for either "already running" or "Unknown instance" in the output before failing
+      "${cmd[@]}" &>"$_tmp" || {
+        grep -q "already running" "$_tmp" || grep -q "Unknown instance:" "$_tmp" || grep -q "is not running" "$_tmp" || fail
+      }
+
+      cmd_out="$("${cmd_status[@]}" 2>&1)"
+      success "{ \"status\": \"${cmd_out}\" }"
+    fi
+
+    # "status" is already pretty terse for these commands
+    cmd_out="$("${cmd_status[@]}" 2>&1)"
     success "{ \"status\": \"${cmd_out}\", \"enabled\": \"${enabled_out}\" }"
 esac

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -6,7 +6,7 @@ declare PT__installdir
 source "$PT__installdir/service/files/common.sh"
 
 # Verify service manager is available
-service_managers=("systemctl" "initctl" "service")
+service_managers=("systemctl" "service" "initctl")
 
 for service in "${service_managers[@]}"; do
   if type "$service" &>/dev/null; then


### PR DESCRIPTION
Prior to this commit, querying for a nonexistent service using some
service managers in the Linux task would return empty values.  This
commit also captures stderr in status checks to accurately convey that
the service is unknown (or any other error).

This also breaks out service and initctl into their own case statements,
as well as fixes a couple of minor bugs around trying to start or stop
a service already in the desired state returning an error.