### PR TITLE
(MODULES-9979) Fix empty return values in Linux task

### DIFF
--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -38,6 +38,19 @@ describe 'linux service task', unless: os[:family] == 'windows' do
     end
   end
 
+  context 'when a service does not exist' do
+    let(:non_existent_service) { 'foo' }
+
+    it 'reports useful information for status' do
+      params = { 'action' => 'restart', 'name' => 'foo' }
+      result = run_bolt_task('service::linux', params, expect_failures: true)
+      expect(result['result']).to include('status' => 'failure')
+      expect(result['result']['_error']).to include('msg' => %r{#{non_existent_service}})
+      expect(result['result']['_error']).to include('kind' => 'bash-error')
+      expect(result['result']['_error']).to include('details')
+    end
+  end
+
   context 'when puppet-agent feature not available on target' do
     before(:all) do
       target = targeting_localhost? ? 'litmus_localhost' : ENV['TARGET_HOST']


### PR DESCRIPTION
Prior to this commit, querying for a nonexistent service using some
service managers in the Linux task would return empty values. This
commit also captures stderr in status checks to accurately convey that
the service is unknown (or any other error).

Co-authored-by: m0dular <sensei.loafage@gmail.com>
Co-authored-by: donoghuc <cas.donoghue@gmail.com>