### PR TITLE
(MAINT) Fix Case Statement Logic

### DIFF
--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -45,11 +45,37 @@ case "$available_manager" in
     fi
     ;;
 
-  # These commands seem to only differ slightly in their invocation
-  "service"|"initctl")
-    if [[ $service == "service" ]]; then
-      cmd=("$service" "$name" "$action")
-      cmd_status=("$service" "$name" "status")
+  "initctl")
+    cmd=("$service" "$action" "$name")
+    cmd_status=("$service" "status" "$name")
+
+    # The initctl show-config output has 'interesting' spacing/tabs, use word splitting to have single spaces
+    word_split=($("$service" show-config "$name" 2>&1))
+    enabled_out="${word_split[@]}"
+
+    if [[ $action != "status" ]]; then
+      # service and initctl may return non-zero if the service is already started or stopped
+      # If so, check for either "already running" or "Unknown instance" or "is not running" in the output before failing
+      "${cmd[@]}" &>"$_tmp" || {
+        grep -q "already running" "$_tmp" || grep -q "Unknown instance:" "$_tmp" || grep -q "is not running" "$_tmp" || fail
+      }
+
+      cmd_out="$("${cmd_status[@]}" 2>&1)"
+      success "{ \"status\": \"${cmd_out}\" }"
+    fi
+
+    # "status" is already pretty terse for these commands
+    cmd_out="$("${cmd_status[@]}" 2>&1)"
+    success "{ \"status\": \"${cmd_out}\", \"enabled\": \"${enabled_out}\" }"
+    ;;
+
+  "service")
+    cmd=("$service" "$name" "$action")
+    cmd_status=("$service" "$name" "status")
+
+    # Several possibilities: chkconfig may be installed, the service may be a SysV job, or it may have been converted to Upstart
+    # This is exactly why we have systemd now
+    if type chkconfig &>/dev/null; then
       # The chkconfig output has 'interesting' spacing/tabs, use word splitting to have single spaces
       word_split=($(chkconfig --list "$name" 2>&1))
     else


### PR DESCRIPTION
This change breaks out service and initctl into their own case statements,
as well as fixes a couple of minor bugs around trying to start or stop
a service already in the desired state returning an error.

Co-authored-by: m0dular <sensei.loafage@gmail.com>
Co-authored-by: donoghuc <cas.donoghue@gmail.com>