### PR TITLE
MODULES-10422 - fix failing tests

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -39,7 +39,7 @@ describe 'service task' do
       result = run_bolt_task('service', 'action' => 'status', 'name' => package_to_use)
       expect(result.exit_code).to eq(0)
       expect(result['result']).to include('status' => %r{running|Started})
-      expect(result['result']).to include('enabled' => %r{true|Manual|Automatic})
+      expect(result['result']).to include('enabled' => %r{true|manual|automatic})
     end
   end
 
@@ -54,7 +54,7 @@ describe 'service task' do
         result = run_bolt_task('service', 'action' => 'status', 'name' => package_to_use)
         expect(result.exit_code).to eq(0)
         expect(result['result']).to include('status' => %r{stopped|Stopped})
-        expect(result['result']).to include('enabled' => %r{true|Manual|Automatic})
+        expect(result['result']).to include('enabled' => %r{true|manual|automatic})
       end
     end
   end
@@ -70,7 +70,7 @@ describe 'service task' do
         result = run_bolt_task('service', 'action' => 'status', 'name' => package_to_use)
         expect(result.exit_code).to eq(0)
         expect(result['result']).to include('status' => %r{running|Started})
-        expect(result['result']).to include('enabled' => %r{true|Manual|Automatic})
+        expect(result['result']).to include('enabled' => %r{true|manual|automatic})
       end
     end
   end


### PR DESCRIPTION
`Successful on 22 nodes: ["tender-carrier.delivery.puppetlabs.net, ubuntu-1804-x86_64", "dim-flop.delivery.puppetlabs.net, debian-8-x86_64", "stale-query.delivery.puppetlabs.net, debian-9-x86_64", "supine-carbine.delivery.puppetlabs.net, ubuntu-1404-x86_64", "unlucky-fast.delivery.puppetlabs.net, ubuntu-1604-x86_64", "curly-kin.delivery.puppetlabs.net, redhat-7-x86_64", "pallid-pit.delivery.puppetlabs.net, scientific-6-x86_64", "tubular-skywave.delivery.puppetlabs.net, oracle-7-x86_64", "dingy-teacher.delivery.puppetlabs.net, win-2016-x86_64", "claret-center.delivery.puppetlabs.net, redhat-6-x86_64", "jiffy-gallium.delivery.puppetlabs.net, centos-6-x86_64", "flat-message.delivery.puppetlabs.net, centos-8-x86_64", "afraid-damsel.delivery.puppetlabs.net, centos-7-x86_64", "crafty-cat.delivery.puppetlabs.net, redhat-8-x86_64", "agile-ban.delivery.puppetlabs.net, scientific-7-x86_64", "restive-dough.delivery.puppetlabs.net, oracle-6-x86_64", "craggy-barge.delivery.puppetlabs.net, win-2012r2-x86_64", "willing-mettle.delivery.puppetlabs.net, win-2008r2-x86_64", "natty-latex.delivery.puppetlabs.net, redhat-5-x86_64", "genetic-tinder.delivery.puppetlabs.net, centos-5-x86_64", "frosty-pen.delivery.puppetlabs.net, oracle-5-x86_64", "legal-scan.delivery.puppetlabs.net, win-10-pro-x86_64"]`