### PR TITLE
MODULES-10422 - fix failing tests

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -34,12 +34,12 @@ describe 'service task' do
     it 'restart/status a service' do
       result = run_bolt_task('service', 'action' => 'restart', 'name' => package_to_use)
       expect(result.exit_code).to eq(0)
-      expect(result['result']).to include('status' => %r{restarted|Restarted})
+      expect(result['result']).to include('status' => %r{restarted}i)
 
       result = run_bolt_task('service', 'action' => 'status', 'name' => package_to_use)
       expect(result.exit_code).to eq(0)
-      expect(result['result']).to include('status' => %r{running|Started})
-      expect(result['result']).to include('enabled' => %r{true|Manual|Automatic})
+      expect(result['result']).to include('status' => %r{running|Started}i)
+      expect(result['result']).to include('enabled' => %r{true|manual|automatic}i)
     end
   end
 
@@ -47,14 +47,14 @@ describe 'service task' do
     it 'stop/status a service' do
       result = run_bolt_task('service', 'action' => 'stop', 'name' => package_to_use)
       expect(result.exit_code).to eq(0)
-      expect(result['result']).to include('status' => %r{in_sync|stopped|Stopped})
+      expect(result['result']).to include('status' => %r{in_sync|stopped}i)
 
       # Debian can give incorrect status
       unless ['debian', 'ubuntu'].include?(os[:family])
         result = run_bolt_task('service', 'action' => 'status', 'name' => package_to_use)
         expect(result.exit_code).to eq(0)
-        expect(result['result']).to include('status' => %r{stopped|Stopped})
-        expect(result['result']).to include('enabled' => %r{true|Manual|Automatic})
+        expect(result['result']).to include('status' => %r{stopped}i)
+        expect(result['result']).to include('enabled' => %r{true|manual|automatic}i)
       end
     end
   end
@@ -63,14 +63,14 @@ describe 'service task' do
     it 'start/status a service' do
       result = run_bolt_task('service', 'action' => 'start', 'name' => package_to_use)
       expect(result.exit_code).to eq(0)
-      expect(result['result']).to include('status' => %r{in_sync|started|Started})
+      expect(result['result']).to include('status' => %r{in_sync|started}i)
 
       # Debian can give incorrect status
       unless ['debian', 'ubuntu'].include?(os[:family])
         result = run_bolt_task('service', 'action' => 'status', 'name' => package_to_use)
         expect(result.exit_code).to eq(0)
-        expect(result['result']).to include('status' => %r{running|Started})
-        expect(result['result']).to include('enabled' => %r{true|Manual|Automatic})
+        expect(result['result']).to include('status' => %r{running|Started}i)
+        expect(result['result']).to include('enabled' => %r{true|manual|automatic}i)
       end
     end
   end


### PR DESCRIPTION
Successful on 24 nodes: ["stylish-ice.delivery.puppetlabs.net, ubuntu-1404-x86_64", "mean-sander.delivery.puppetlabs.net, scientific-7-x86_64", "utter-truism.delivery.puppetlabs.net, win-2016-x86_64", "diverse-bequest.delivery.puppetlabs.net, win-2016-x86_64", "crude-duet.delivery.puppetlabs.net, win-2016-x86_64", "loyal-brothel.delivery.puppetlabs.net, oracle-7-x86_64", "bullish-arnica.delivery.puppetlabs.net, centos-7-x86_64", "stubby-xylem.delivery.puppetlabs.net, centos-6-x86_64", "dumb-caramel.delivery.puppetlabs.net, debian-9-x86_64", "loyal-sound.delivery.puppetlabs.net, redhat-7-x86_64", "dense-hospice.delivery.puppetlabs.net, ubuntu-1604-x86_64", "drowsy-alimony.delivery.puppetlabs.net, oracle-6-x86_64", "myopic-star.delivery.puppetlabs.net, centos-8-x86_64", "masonry-scrub.delivery.puppetlabs.net, redhat-6-x86_64", "prosaic-piece.delivery.puppetlabs.net, win-10-pro-x86_64", "crafty-whiskey.delivery.puppetlabs.net, scientific-6-x86_64", "sleek-matting.delivery.puppetlabs.net, win-2012r2-x86_64", "hairier-amorist.delivery.puppetlabs.net, debian-8-x86_64", "wifely-antenna.delivery.puppetlabs.net, win-2008r2-x86_64", "sweeter-dingo.delivery.puppetlabs.net, centos-5-x86_64", "suable-stab.delivery.puppetlabs.net, ubuntu-1804-x86_64", "fateful-farm.delivery.puppetlabs.net, oracle-5-x86_64", "nice-pecan.delivery.puppetlabs.net, redhat-5-x86_64, "reddish-nagging.delivery.puppetlabs.net, redhat-8-x86_64"]