### PR TITLE
(maint) Add enable and disable actions for *nix

### DIFF
--- a/spec/acceptance/linux_spec.rb
+++ b/spec/acceptance/linux_spec.rb
@@ -37,6 +37,23 @@ describe 'linux service task', unless: os[:family] == 'windows' do
       expect(result['result']).to include('status' => %r{ActiveState=active|running})
     end
   end
+  
+  describe 'enable action' do
+    it "enable #{package_to_use}" do
+      result = run_bolt_task('service::linux', 'action' => 'enable', 'name' => package_to_use)
+      expect(result.exit_code).to eq(0)
+      expect(result['result']).to include('enabled' => 'enabled')
+    end
+  end
+
+  describe 'disable action' do
+    it "disable #{package_to_use}" do
+      result = run_bolt_task('service::linux', 'action' => 'disable', 'name' => package_to_use)
+      expect(result.exit_code).to eq(0)
+      expect(result['result']).to include('enabled' => 'disabled')
+    end
+  end
+
 
   context 'when puppet-agent feature not available on target' do
     before(:all) do
@@ -47,24 +64,10 @@ describe 'linux service task', unless: os[:family] == 'windows' do
       end
     end
 
-    it 'enable action fails' do
-      skip('Cannot mock inventory features during localhost acceptance testing') if ENV['TARGET_HOST'] == 'localhost'
-      params = { 'action' => 'enable', 'name' => package_to_use }
-      result = run_bolt_task('service', params, expect_failures: true)
-      expect(result['result']).to include('status' => 'failure')
-      expect(result['result']['_error']).to include('msg' => %r{'enable' action not supported})
-      expect(result['result']['_error']).to include('kind' => 'bash-error')
-      expect(result['result']['_error']).to include('details')
-    end
-
-    it 'disable action fails' do
-      skip('Cannot mock inventory features during localhost acceptance testing') if ENV['TARGET_HOST'] == 'localhost'
-      params = { 'action' => 'disable', 'name' => package_to_use }
-      result = run_bolt_task('service', params, expect_failures: true)
-      expect(result['result']).to include('status' => 'failure')
-      expect(result['result']['_error']).to include('msg' => %r{'disable' action not supported})
-      expect(result['result']['_error']).to include('kind' => 'bash-error')
-      expect(result['result']['_error']).to include('details')
+    it 'does not use the ruby task' do
+      result = run_bolt_task('service', 'action' => 'restart', 'name' => package_to_use)
+      expect(result.exit_code).to eq(0)
+      expect(result['result']).to include('status' => %r{ActiveState=active|running})
     end
   end
 end

--- a/tasks/linux.json
+++ b/tasks/linux.json
@@ -4,8 +4,8 @@
   "input_method": "environment",
   "parameters": {
     "action": {
-      "description": "The operation (start, stop, restart, status) to perform on the service.",
-      "type": "Enum[start, stop, restart, status]"
+      "description": "The operation (start, stop, restart, status, enable, disable) to perform on the service.",
+      "type": "Enum[start, stop, restart, status, enable, disable]"
     },
     "name": {
       "description": "The name of the service to operate on.",

--- a/tasks/linux.sh
+++ b/tasks/linux.sh
@@ -21,7 +21,7 @@ done
 
 # Verify only allowable actions are specified
 case "$action" in
-  "start"|"stop"|"restart"|"status");;
+  "start"|"stop"|"restart"|"status"|"enable"|"disable");;
   *) validation_error "'${action}' action not supported for linux.sh"
 esac
 
@@ -37,11 +37,12 @@ case "$available_manager" in
     # sample output: "MainPID=23377,LoadState=loaded,ActiveState=active"
     cmd_out="$("$service" "show" "$name" -p LoadState -p MainPID -p ActiveState --no-pager | paste -sd ',' -)"
 
-    if [[ $action != "status" ]]; then
-      success "{ \"status\": \"${cmd_out}\" }"
-    else
+    $cmds = ("status", "enable", "disable")
+    if [[ " ${cmds[@]} " =~ " ${action} " ]]; then
       enabled_out="$("$service" "is-enabled" "$name")"
       success "{ \"status\": \"${cmd_out}\", \"enabled\": \"${enabled_out}\" }"
+    else
+      success "{ \"status\": \"${cmd_out}\" }"
     fi
     ;;
 


### PR DESCRIPTION
This adds 'enable' and 'disable' actions to the linux service task,
allowing users to enable or disable a service using the task.