### PR TITLE
pdksync - (CAT-343) Audit modules and tools for references to travis. Removed all needless references to travis.

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -9,24 +9,24 @@ vagrant:
   - centos/7
   - generic/ubuntu1804
   - gusztavvargadr/windows-server
-travis_deb:
+docker_deb:
   provisioner: docker
   images:
   - litmusimage/debian:8
   - litmusimage/debian:9
-travis_ub:
+docker_ub:
   provisioner: docker
   images:
   - litmusimage/ubuntu:14.04
   - litmusimage/ubuntu:16.04
   - litmusimage/ubuntu:18.04
-travis_el7:
+docker_el7:
   provisioner: docker
   images:
   - litmusimage/centos:7
   - litmusimage/oraclelinux:7
   - litmusimage/scientificlinux:7
-travis_el8:
+docker_el8:
   provisioner: docker
   images:
   - litmusimage/centos:8


### PR DESCRIPTION
(CAT-343) Audit modules and tools for references to travis. Removed all needless references to travis.
pdk version: `2.7.0` 
